### PR TITLE
remove wan submodule

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,6 @@ The Initial Developer of the Covered Software is
         <module>../toolkit-runtime-ee</module>
         <module>../toolkit-ee-system-tests</module>
         <module>../toolkit-lrt-system-tests</module>
-        <module>../wan-standalone</module>
       </modules>
     </profile>
 


### PR DESCRIPTION
That's the only change I see so far.  Once merged, a PR will be needed for enterprise to update the git submodule commit.