### PR TITLE
Always reset root logger, even for custom logging.

### DIFF
--- a/common/src/main/resources/com/tc/properties/tc.properties
+++ b/common/src/main/resources/com/tc/properties/tc.properties
@@ -348,10 +348,14 @@ l1.lockmanager.pinning.enabled = true
 # Description       : Logging attributes that can be overridden.
 # maxBackups        : The maximum number of backup log files to keep
 # maxLogFileSize    : The maximum size of a log file in megabytes
+# backupFileSuffix  : To be used for adding a backup suffix that logback will use to determine if
+#                     compression is enabled. If undefined, defaults to the empty string, resulting in no compression.
+#                     Valid options are: .gz, .zip, <empty-string> (no compression, default)
 # longgc.threshold  : JVM GC taking greater than the time mentioned will be logged
 ###########################################################################################
 logging.maxBackups = 20
 logging.maxLogFileSize = 512
+logging.backupFileSuffix =
 logging.longgc.threshold = 8000
 
 ###########################################################################################


### PR DESCRIPTION
Add ability to have rolled-over log files compressed via a tc.property.