### PR TITLE
Run no tests unless system-tests profile is on (daggy main)

### DIFF
--- a/system-tests-parent/pom.xml
+++ b/system-tests-parent/pom.xml
@@ -82,6 +82,7 @@ The Initial Developer of the Covered Software is
         C:\DOCUME~1\${user.name}\.m2\repository to avoid spaces in the path
         (see the container-tests-windows profile definition).
     -->
+    <skipTests>true</skipTests> <!-- turned on if -Psystem-tests is passed -->
     <localMavenRepository>${user.home}/.m2/repository</localMavenRepository>
     <os-classifier>linux</os-classifier>
   </properties>
@@ -357,6 +358,13 @@ The Initial Developer of the Covered Software is
   </build>
 
   <profiles>
+    <profile>
+      <id>system-tests</id>
+      <properties>
+        <skipTests>false</skipTests>
+      </properties>
+    </profile>
+
     <profile>
       <id>workaround-windows</id>
       <activation>


### PR DESCRIPTION
Restoring part of the old functionality:
* without `-Psystem-tests`, skip all tests on system-test modules
* with `-Psystem-tests`, run them in integration-test phase as defined in forge-parent
* with `-Psystem-tests -DskipTests`, all tests are still skipped