### PR TITLE
Support env memory overrides to start-tc-server (daggy main)

### DIFF
--- a/terracotta-kit/src/assemble/server/bin/start-tc-server.bat
+++ b/terracotta-kit/src/assemble/server/bin/start-tc-server.bat
@@ -54,12 +54,16 @@ for %%C in ("\bin\java -d64 -server -XX:MaxDirectMemorySize=9223372036854775807"
   )
 )
 
+if not defined JAVA_MEMORY_OPTS (
+ set JAVA_MEMORY_OPTS=-Xms2g -Xmx2g
+)
+
 rem rmi.dgc.server.gcInterval is set an year to avoid system gc in case authentication is enabled
 rem users may change it accordingly
 
 :found_command
 set CLASSPATH=%TC_INSTALL_DIR%\server\lib\tc.jar
-set OPTS=%SERVER_OPT% -Xms2g -Xmx2g -XX:+HeapDumpOnOutOfMemoryError
+set OPTS=%SERVER_OPT% %JAVA_MEMORY_OPTS% -XX:+HeapDumpOnOutOfMemoryError
 set OPTS=%OPTS% -Dcom.sun.management.jmxremote
 set OPTS=%OPTS% -Dsun.rmi.dgc.server.gcInterval=31536000000
 set OPTS=%OPTS% -Dtc.install-root=%TC_INSTALL_DIR%

--- a/terracotta-kit/src/assemble/server/bin/start-tc-server.sh
+++ b/terracotta-kit/src/assemble/server/bin/start-tc-server.sh
@@ -35,6 +35,7 @@ esac
 
 THIS_DIR=`dirname $0`
 TC_INSTALL_DIR=`cd $THIS_DIR;pwd`/../..
+JAVA_MEMORY_OPTS=${JAVA_MEMORY_OPTS:-"-Xms2g -Xmx2g"}
 
 if [ -r "$TC_INSTALL_DIR"/server/bin/setenv.sh ] ; then
   . "$TC_INSTALL_DIR"/server/bin/setenv.sh
@@ -67,7 +68,7 @@ args="$@"
 start=true
 while "$start"
 do
-eval ${JAVA_COMMAND} -Xms2g -Xmx2g -XX:+HeapDumpOnOutOfMemoryError \
+eval ${JAVA_COMMAND} ${JAVA_MEMORY_OPTS} -XX:+HeapDumpOnOutOfMemoryError \
    -Dcom.sun.management.jmxremote \
    -Dtc.install-root="${TC_INSTALL_DIR}" \
    -Dsun.rmi.dgc.server.gcInterval=31536000000\


### PR DESCRIPTION
Currently `-Xms2g -Xmx2g` is hardcoded.

There are 3 PRs, a review of just this one is all I need.