### PR TITLE
[daggy][main] Fix script: mod_args must be unset otherwise CLI parameters are appended again and again upon restarts

### DIFF
--- a/terracotta-kit/src/assemble/server/bin/start-tc-server.sh
+++ b/terracotta-kit/src/assemble/server/bin/start-tc-server.sh
@@ -70,6 +70,7 @@ args="$@"
 start=true
 while "$start"
 do
+unset mod_args
 eval ${JAVA_COMMAND} -Xms2g -Xmx2g -XX:+HeapDumpOnOutOfMemoryError \
    -Dcom.sun.management.jmxremote \
    -Dtc.install-root="${TC_INSTALL_DIR}" \


### PR DESCRIPTION
Proof of the bug: just update the script as is:

```
# eval ${JAVA_COMMAND} -Xms2g -Xmx2g -XX:+HeapDumpOnOutOfMemoryError \
#    -Dcom.sun.management.jmxremote \
#    -Dtc.install-root="${TC_INSTALL_DIR}" \
#    -Dsun.rmi.dgc.server.gcInterval=31536000000\
#    ${JAVA_OPTS} \
#    -cp "${TC_INSTALL_DIR}/server/lib/tc.jar" \
#    com.tc.server.TCServerMain $args
echo "args=$args"
echo "mod_args=$mod_args"
sleep 1 && groovy -e "System.exit(11)"
```

and run:

`./start-tc-server.sh -f foo -n bar`

it will output:

```
args=-f foo -n bar
mod_args=
start-tc-server: Restarting the server...
args= -f foo -n bar
mod_args= -f foo -n bar
start-tc-server: Restarting the server...
args= -f foo -n bar -f foo -n bar
mod_args= -f foo -n bar -f foo -n bar
start-tc-server: Restarting the server...
args= -f foo -n bar -f foo -n bar -f foo -n bar -f foo -n bar
mod_args= -f foo -n bar -f foo -n bar -f foo -n bar -f foo -n bar
start-tc-server: Restarting the server...
args= -f foo -n bar -f foo -n bar -f foo -n bar -f foo -n bar -f foo -n bar -f foo -n bar -f foo -n bar -f foo -n bar
mod_args= -f foo -n bar -f foo -n bar -f foo -n bar -f foo -n bar -f foo -n bar -f foo -n bar -f foo -n bar -f foo -n bar
```

to fix it we just have to add: `unset mod_args` just after the `do`:

```
❯  ./start-tc-server.sh -f foo -n bar
args=-f foo -n bar
mod_args=
start-tc-server: Restarting the server...
args= -f foo -n bar
mod_args=
start-tc-server: Restarting the server...
args= -f foo -n bar
mod_args=
start-tc-server: Restarting the server...
args= -f foo -n bar
mod_args=
```