### PR TITLE
Reference cloud module in a profile for versions:set (daggy main)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,14 @@ The Initial Developer of the Covered Software is
       </modules>
     </profile>
   
+    <!-- Allow building cloud stuff from top level (and automatic versions:set support for those poms) -->
+    <profile>
+      <id>cloud</id>
+      <modules>
+        <module>../cloud/images</module>
+      </modules>
+    </profile>
+
     <!-- activate to include EE modules if it's EE branch -->
     <profile>
       <id>include-ee-modules</id>


### PR DESCRIPTION
This seems to be sufficient for `mvn versions:set` to update the poms during tagging (no profiles need to be activated), but keeps it out of the normal build.