### PR TITLE
If Logback is not bound to slf4j create a standalone context for our logging

### DIFF
--- a/common/src/main/java/com/tc/logging/TCLogging.java
+++ b/common/src/main/java/com/tc/logging/TCLogging.java
@@ -31,6 +31,7 @@ import ch.qos.logback.core.util.FileSize;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
+import org.slf4j.ILoggerFactory;
 import org.slf4j.LoggerFactory;
 
 import com.tc.properties.TCProperties;
@@ -514,7 +515,13 @@ public class TCLogging {
 
   public static LoggerContext getLoggerContext() {
     if (loggerContext == null) {
-      loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+      ILoggerFactory logbackViaSlf4j = LoggerFactory.getILoggerFactory();
+      if (logbackViaSlf4j instanceof LoggerContext) {
+        loggerContext = (LoggerContext) logbackViaSlf4j;
+      } else {
+        loggerContext = new LoggerContext();
+        loggerContext.getLogger(TCLogging.class).warn("Logback was not the bound Slf4J provider. Using a standalone Logback LoggerContext to back TCLogging.");
+      }
     }
     return loggerContext;
   }


### PR DESCRIPTION
When the tc-maven-plugin tries to use the config classes to run tests it runs in to issues because the Slf4J binding it sees is the Maven one (which isn't logbook). To work around this issue I've allowed TCLogging to fallback to a private logging context if the retrieved slf4j binding isn't logbook. I haven't tested this... but I think it will work. Someone might want to take this and either verify it manually... or add some automated test coverage to confirm everything is okay.