### PR TITLE
TAB-8330 Vulnerable 3rd party component json-smart used

### DIFF
--- a/management-cli-oss/pom.xml
+++ b/management-cli-oss/pom.xml
@@ -54,6 +54,10 @@
       <artifactId>json-path</artifactId>
     </dependency>
     <dependency>
+      <groupId>net.minidev</groupId>
+      <artifactId>json-smart</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
     </dependency>


### PR DESCRIPTION
Fixed by upgrading json-path 2.7.0 to 2.8.0 and json-smart 2.4.7 to 2.4.10.
Fixed by adding json-smart in management-cli-oss maven build and adding it to 3rd party bom.