### PR TITLE
Remove 1. prefix for java version because forge-parent adds it (Daggy 4.3.10)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,5 +27,5 @@ jobs:
   - template: build-templates/maven-common.yml@templates
     parameters:
       jobName: Linux_Java_8
-      options: -B -Djava.test.version=1.8 -Djava.test.vendor=zulu -Pfullmode,check-short -Dsag-deps=true -DskipCheckstyle -DskipJavadoc
+      options: -B -Djava.test.version=8 -Djava.test.vendor=zulu -Pfullmode,check-short -Dsag-deps=true -DskipCheckstyle -DskipJavadoc
       mavenGoals: 'clean install' # verify won't work because of funky poms


### PR DESCRIPTION
With a the [recent upgrade of forge-parent](https://github.com/GaryWKeim/dso/commit/cf4545ba971b484a1442602dd410652694909d17), java version needs to be specified without the `1.` prefix 