### PR TITLE
[4.3.10] Release MappedByteBuffer for Windows

### DIFF
--- a/common/src/test/java/com/tc/util/Grep.java
+++ b/common/src/test/java/com/tc/util/Grep.java
@@ -1,7 +1,7 @@
-/* 
+/*
  * The contents of this file are subject to the Terracotta Public License Version
  * 2.0 (the "License"); You may not use this file except in compliance with the
- * License. You may obtain a copy of the License at 
+ * License. You may obtain a copy of the License at
  *
  *      http://terracotta.org/legal/terracotta-public-license.
  *
@@ -11,58 +11,58 @@
  *
  * The Covered Software is Terracotta Platform.
  *
- * The Initial Developer of the Covered Software is 
+ * The Initial Developer of the Covered Software is
  *      Terracotta, Inc., a Software AG company
  */
 package com.tc.util;
 
 /**
  * <pre>
- * The original code is found at http://java.sun.com/j2se/1.4.2/docs/guide/nio/example 
- * 
+ * The original code is found at http://java.sun.com/j2se/1.4.2/docs/guide/nio/example
+ *
  * Modified by hhuynh to return list of CharSequence
  * </pre>
- * 
+ *
  * <pre>
  * &#064;(#)Grep.java  1.3 01/12/13
  * Search a list of files for lines that match a given regular-expression
  * pattern.  Demonstrates NIO mapped byte buffers, charsets, and regular
  * expressions.
- * 
+ *
  * Copyright 2001-2002 Sun Microsystems, Inc. All Rights Reserved.
- * 
- * Redistribution and use in source and binary forms, with or 
- * without modification, are permitted provided that the following 
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
  * conditions are met:
- * 
- * -Redistributions of source code must retain the above copyright  
+ *
+ * -Redistributions of source code must retain the above copyright
  * notice, this  list of conditions and the following disclaimer.
- * 
- * -Redistribution in binary form must reproduct the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
+ *
+ * -Redistribution in binary form must reproduct the above copyright
+ * notice, this list of conditions and the following disclaimer in
+ * the documentation and/or other materials provided with the
  * distribution.
- * 
- * Neither the name of Sun Microsystems, Inc. or the names of 
- * contributors may be used to endorse or promote products derived 
+ *
+ * Neither the name of Sun Microsystems, Inc. or the names of
+ * contributors may be used to endorse or promote products derived
  * from this software without specific prior written permission.
- * 
- * This software is provided &quot;AS IS,&quot; without a warranty of any 
- * kind. ALL EXPRESS OR IMPLIED CONDITIONS, REPRESENTATIONS AND 
- * WARRANTIES, INCLUDING ANY IMPLIED WARRANTY OF MERCHANTABILITY, 
- * FITNESS FOR A PARTICULAR PURPOSE OR NON-INFRINGEMENT, ARE HEREBY 
- * EXCLUDED. SUN AND ITS LICENSORS SHALL NOT BE LIABLE FOR ANY 
- * DAMAGES OR LIABILITIES  SUFFERED BY LICENSEE AS A RESULT OF  OR 
- * RELATING TO USE, MODIFICATION OR DISTRIBUTION OF THE SOFTWARE OR 
- * ITS DERIVATIVES. IN NO EVENT WILL SUN OR ITS LICENSORS BE LIABLE 
- * FOR ANY LOST REVENUE, PROFIT OR DATA, OR FOR DIRECT, INDIRECT, 
- * SPECIAL, CONSEQUENTIAL, INCIDENTAL OR PUNITIVE DAMAGES, HOWEVER 
- * CAUSED AND REGARDLESS OF THE THEORY OF LIABILITY, ARISING OUT OF 
- * THE USE OF OR INABILITY TO USE SOFTWARE, EVEN IF SUN HAS BEEN 
+ *
+ * This software is provided &quot;AS IS,&quot; without a warranty of any
+ * kind. ALL EXPRESS OR IMPLIED CONDITIONS, REPRESENTATIONS AND
+ * WARRANTIES, INCLUDING ANY IMPLIED WARRANTY OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE OR NON-INFRINGEMENT, ARE HEREBY
+ * EXCLUDED. SUN AND ITS LICENSORS SHALL NOT BE LIABLE FOR ANY
+ * DAMAGES OR LIABILITIES  SUFFERED BY LICENSEE AS A RESULT OF  OR
+ * RELATING TO USE, MODIFICATION OR DISTRIBUTION OF THE SOFTWARE OR
+ * ITS DERIVATIVES. IN NO EVENT WILL SUN OR ITS LICENSORS BE LIABLE
+ * FOR ANY LOST REVENUE, PROFIT OR DATA, OR FOR DIRECT, INDIRECT,
+ * SPECIAL, CONSEQUENTIAL, INCIDENTAL OR PUNITIVE DAMAGES, HOWEVER
+ * CAUSED AND REGARDLESS OF THE THEORY OF LIABILITY, ARISING OUT OF
+ * THE USE OF OR INABILITY TO USE SOFTWARE, EVEN IF SUN HAS BEEN
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
- * 
- * You acknowledge that Software is not designed, licensed or 
- * intended for use in the design, construction, operation or 
+ *
+ * You acknowledge that Software is not designed, licensed or
+ * intended for use in the design, construction, operation or
  * maintenance of any nuclear facility.
  * </pre>
  */
@@ -70,6 +70,8 @@ package com.tc.util;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.lang.ref.PhantomReference;
+import java.lang.ref.ReferenceQueue;
 import java.nio.CharBuffer;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
@@ -110,23 +112,39 @@ public class Grep {
   // Search for occurrences of the input pattern in the given file
   //
   public static List<CharSequence> grep(String pat, File f) throws IOException {
+    ReferenceQueue<MappedByteBuffer> refQueue = new ReferenceQueue<>();
+    PhantomReference<MappedByteBuffer> ref = null;
     // Open the file and then get a channel from the stream
-    FileInputStream fis = new FileInputStream(f);
-    FileChannel fc = fis.getChannel();
+    try {
+      try (FileInputStream fis = new FileInputStream(f);
+           FileChannel fc = fis.getChannel()) {
 
-    // Get the file's size and then map it into memory
-    int sz = (int) fc.size();
-    MappedByteBuffer bb = fc.map(FileChannel.MapMode.READ_ONLY, 0, sz);
+        // Get the file's size and then map it into memory
+        int sz = (int)fc.size();
+        MappedByteBuffer bb = fc.map(FileChannel.MapMode.READ_ONLY, 0, sz);
+        ref = new PhantomReference<>(bb, refQueue);
 
-    // Decode the file into a char buffer
-    CharBuffer cb = decoder.decode(bb);
+        // Decode the file into a char buffer
+        CharBuffer cb = decoder.decode(bb);
+        bb = null;    // Encourages GC
 
-    // Perform the search
-    List<CharSequence> result = grep(pat, cb);
+        // Perform the search
+        return grep(pat, cb);
+      }
 
-    // Close the channel and the stream
-    fc.close();
-
-    return result;
+    } finally {
+      if (ref != null) {
+        while (refQueue.poll() != ref) {
+          System.gc();
+          System.runFinalization();
+          try {
+            Thread.sleep(100L);
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            break;
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
This commit encourages release of the MappedByteBuffer used by Grep for scanning.  Retention of the MappedByteBuffer holds open an FD which prevents re-use of the file on Windows.

Daggy for main, release/4.4.0, and release/4.3.10.