### PR TITLE
TAB-9575: REST endpoints now throw 403 (FORBIDDEN) when appropriate.

### DIFF
--- a/deploy/src/main/java/com/tc/admin/TCStop.java
+++ b/deploy/src/main/java/com/tc/admin/TCStop.java
@@ -194,6 +194,8 @@ public class TCStop {
           return;
         } else if (response.getStatus() == 401) {
           throw new IOException("Authentication error while connecting to " + hostPort + ", check username/password and try again.");
+        } else if (response.getStatus() == 403) {
+          throw new IOException("Insufficient permissions to perform a server shutdown.");
         } else if (response.getStatus() == 404) {
           consoleLogger.warn("Got a 404 while connecting to " + hostPort + ". Management service might not be started " +
             "yet; retrying.");

--- a/deploy/src/test/java/com/tc/admin/TCStopTest.java
+++ b/deploy/src/test/java/com/tc/admin/TCStopTest.java
@@ -78,7 +78,7 @@ public class TCStopTest {
   public void testUnknownError() throws Exception {
     WebTarget target = mockWebTarget("localhost", 12323);
     responseCode(target, 403);
-    String errorMessage = "critical failure";
+    String errorMessage = "Insufficient permissions to perform a server shutdown.";
     when(target.request(MediaType.APPLICATION_JSON_TYPE)
         .post(Entity.json(null))
         .readEntity(any(Class.class))).thenReturn(

--- a/management-agent/management-tsa-common/src/main/java/com/terracotta/management/web/shiro/TSAIniWebEnvironment.java
+++ b/management-agent/management-tsa-common/src/main/java/com/terracotta/management/web/shiro/TSAIniWebEnvironment.java
@@ -17,15 +17,17 @@
 package com.terracotta.management.web.shiro;
 
 import org.apache.shiro.web.env.IniWebEnvironment;
-
-import com.terracotta.management.web.utils.TSAConfig;
+import org.terracotta.management.security.web.shiro.TCWebIniSecurityManagerFactory;
 
 /**
  * @author Ludovic Orban
  */
 public class TSAIniWebEnvironment extends IniWebEnvironment {
+  protected final static String UNSECURE_INI_RESOURCE_PATH = "classpath:shiro.ini";
 
-  private final static String UNSECURE_INI_RESOURCE_PATH = "classpath:shiro.ini";
+  public TSAIniWebEnvironment() {
+    setSecurityManagerFactory(new TCWebIniSecurityManagerFactory());
+  }
 
   @Override
   protected String[] getDefaultConfigLocations() {


### PR DESCRIPTION
REST endpoints protected from unauthorized usage by Shiro (operator role can only successfully invoke GET)